### PR TITLE
Trivial rebranding so Chips identifies itself correctly on start+stop

### DIFF
--- a/src/bitcoind.cpp
+++ b/src/bitcoind.cpp
@@ -147,7 +147,7 @@ bool AppInit(int argc, char* argv[])
         if (GetBoolArg("-daemon", false))
         {
 #if HAVE_DECL_DAEMON
-            fprintf(stdout, "Bitcoin server starting\n");
+            fprintf(stdout, "Chips server starting\n");
 
             // Daemonize
             if (daemon(1, 0)) { // don't chdir (1), do close FDs (0)

--- a/src/rpc/mining.cpp
+++ b/src/rpc/mining.cpp
@@ -440,10 +440,10 @@ UniValue getblocktemplate(const JSONRPCRequest& request)
         throw JSONRPCError(RPC_CLIENT_P2P_DISABLED, "Error: Peer-to-peer functionality missing or disabled");
 
     if (g_connman->GetNodeCount(CConnman::CONNECTIONS_ALL) == 0)
-        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Bitcoin is not connected!");
+        throw JSONRPCError(RPC_CLIENT_NOT_CONNECTED, "Chips is not connected!");
 
     if (IsInitialBlockDownload())
-        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Bitcoin is downloading blocks...");
+        throw JSONRPCError(RPC_CLIENT_IN_INITIAL_DOWNLOAD, "Chips is downloading blocks...");
 
     static unsigned int nTransactionsUpdatedLast;
 

--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -240,11 +240,11 @@ UniValue stop(const JSONRPCRequest& jsonRequest)
     if (jsonRequest.fHelp || jsonRequest.params.size() > 1)
         throw std::runtime_error(
             "stop\n"
-            "\nStop Bitcoin server.");
+            "\nStop Chips server.");
     // Event loop will exit after current HTTP requests have been handled, so
     // this reply will get back to the client.
     StartShutdown();
-    return "Bitcoin server stopping";
+    return "Chips server stopping";
 }
 
 UniValue uptime(const JSONRPCRequest& jsonRequest)


### PR DESCRIPTION
It's nice for exchanges and mining pools to see the correct coin name when starting+stopping the server.