### PR TITLE
Fix dpowconfs compile error and add build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# EMC2 build script for Ubuntu & Debian 9 v.3 (c) Decker (and webworker)
+# modified for CHIPS by Duke Leto
+
+berkeleydb () {
+    CHIPS_ROOT=$(pwd)
+    CHIPS_PREFIX="${CHIPS_ROOT}/db4"
+    mkdir -p $CHIPS_PREFIX
+    wget -N 'http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz'
+    echo '12edc0df75bf9abd7f82f821795bcee50f42cb2e5f76a6a281b85732798364ef db-4.8.30.NC.tar.gz' | sha256sum -c
+    tar -xzvf db-4.8.30.NC.tar.gz
+    cd db-4.8.30.NC/build_unix/
+
+    ../dist/configure -enable-cxx -disable-shared -with-pic -prefix=$CHIPS_PREFIX
+
+    make install
+    cd $CHIPS_ROOT
+}
+
+buildchips () {
+    git pull
+    make clean
+    ./autogen.sh
+    ./configure LDFLAGS="-L${CHIPS_PREFIX}/lib/" CPPFLAGS="-I${CHIPS_PREFIX}/include/" --with-gui=no --disable-tests --disable-bench --without-miniupnpc --enable-experimental-asm --enable-static --disable-shared
+    make -j$(nproc)
+}
+
+berkeleydb
+buildchips
+echo "Done building CHIPS!"

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -1539,6 +1539,7 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool by_l
         {
             CAmount nAmount = entry.second.nAmount;
             int nConf = entry.second.nConf;
+            int nHeight = entry.second.nHeight;
             UniValue obj(UniValue::VOBJ);
             if (entry.second.fIsWatchonly)
                 obj.pushKV("involvesWatchonly", true);


### PR DESCRIPTION
This build.sh should make building a lot simpler for the average user needs.

Advanced users can still use things directly.