### PR TITLE
Fix dpowconfs: Mixa84 fix and case confirmations <= 0

### DIFF
--- a/src/komodo_rpcblockchain.h
+++ b/src/komodo_rpcblockchain.h
@@ -35,7 +35,7 @@ int32_t komodo_dpowconfs(int32_t txheight,int32_t numconfs)
             if ( txheight < NOTARIZED_HEIGHT )
                 return(numconfs);
             else return(1);
-        }
+        } else return(1);
     }
     return(numconfs);
 }

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -110,6 +110,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
         entry.pushKV("blockindex", wtx.nIndex);
         entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
     } else {
+        entry.pushKV("confirmations", 0);
         entry.pushKV("trusted", wtx.IsTrusted());
     }
     uint256 hash = wtx.GetHash();
@@ -1515,7 +1516,6 @@ UniValue ListReceived(CWallet * const pwallet, const UniValue& params, bool by_l
             obj.pushKV("address",       EncodeDestination(address));
             obj.pushKV("account",       label);
             obj.pushKV("amount",        ValueFromAmount(nAmount));
-            obj.pushKV("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf));
             obj.pushKV("rawconfirmations", (nConf == std::numeric_limits<int>::max() ? 0 : nConf));
             obj.pushKV("confirmations", (nConf == std::numeric_limits<int>::max() ? 0 : komodo_dpowconfs(nHeight, nConf)));
 

--- a/src/wallet/rpcwallet.cpp
+++ b/src/wallet/rpcwallet.cpp
@@ -110,7 +110,7 @@ void WalletTxToJSON(const CWalletTx& wtx, UniValue& entry)
         entry.pushKV("blockindex", wtx.nIndex);
         entry.pushKV("blocktime", LookupBlockIndex(wtx.hashBlock)->GetBlockTime());
     } else {
-        entry.pushKV("confirmations", 0);
+        entry.pushKV("confirmations", confirms);
         entry.pushKV("trusted", wtx.IsTrusted());
     }
     uint256 hash = wtx.GetHash();


### PR DESCRIPTION
https://github.com/Mixa84/komodo/commit/28d3cff284f5d4fd6f0e2642d952b2a49f61896b


L113: When block is found but not yet confirmed by network (or orphan), the confirmations field of gettransaction should be present.
https://github.com/bitcoin/bitcoin/blob/0.16/src/wallet/rpcwallet.cpp#L89

I had an error before this fix because confirmations field was not present in some rare cases. Unfortunately, the error happened at each block found on the yiimp pool:
```array
(
    'amount' => 0
    'rawconfirmations' => 0
    'generated' => true
    'trusted' => false
    'txid' => '97f7051aefdaaf862276a349f3de224a47c75b043858c796a49018ac467103ca'
    'walletconflicts' => array()
    'time' => 1563655579
    'timereceived' => 1563655597
    'bip125-replaceable' => 'yes'
    'details' => array
    (
        0 => array(...)
    )
    'hex' => '02000000010000000000000000000000000000000000000000000000000000000000000000ffffffff1803dcf13f049b7d335d088100000f7fe500007969696d70000000000001402500000000000017a914df965449a9d70b449b5044fb4b0547e86ddb0ba88700000000'
)```

For documentation, here was another possibility to fix the issue on pool side:
https://github.com/tpruvot/yiimp/commit/63baeab05dd4bf353061acbd687b3ec9ad2107b2

L1518: Remove duplicate confirmations field