### PR TITLE
fix windows x64 cross-compilation

### DIFF
--- a/src/cryptoconditions/src/secp256k1.c
+++ b/src/cryptoconditions/src/secp256k1.c
@@ -1,6 +1,11 @@
 #define _GNU_SOURCE 1
 
+#if __linux
 #include <sys/syscall.h>
+#elif defined(_WIN32) || defined(_WIN64)
+#include <windows.h>
+#endif
+
 #include <unistd.h>
 #include <pthread.h>
 


### PR DESCRIPTION
This PR fixes the build issue described by grewalsatinder [here](https://discord.com/channels/455737840169386016/455737840668770315/770270078809276429).

Just for info, common steps to cross-compile static binaries for Windows x64 under Ubuntu 18.04:

```
git clone https://github.com/jl777/chips3
cd chips3/
git checkout dev
cd depends/
make HOST=x86_64-w64-mingw32 -j$(nproc)
cd ..
./autogen.sh 
./configure --prefix=$(pwd)/depends/x86_64-w64-mingw32 --disable-tests --disable-bench --without-miniupnpc --enable-experimental-asm --enable-static --disable-shared
make -j$(nproc)
```