### PR TITLE
AdaptivePoW integration: fix compilation warnings

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -141,7 +141,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
         {
             // too fast or stuck, this addresses the too fast issue, while moving
             // forward as quickly as possible
-            for (int i; i < 100; i++)
+            for (int i = 0; i < 100; i++)
             {
                 proposedTime = GetAdjustedTime();
                 if (proposedTime == nMedianTimePast)

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -85,7 +85,7 @@ arith_uint256 oldRT_CST_RST(int32_t height,uint32_t nTime,arith_uint256 bnTarget
     if ( height < 64 )
         return(bnTarget);
     //if ( ((ts[0]-ts[W]) * W * 100)/(W-1) < (T * numerator * 100)/denominator )
-    if ( (uint32_t)(ts[0] - ts[W]) < (T * numerator)/denominator )
+    if ( (int32_t) (ts[0] - ts[W]) < (int32_t) (T * numerator)/denominator )
     {
         //bnTarget = ((ct[0]-ct[1])/K) * max(K,(K*(nTime-ts[0])*(ts[0]-ts[W])*denominator/numerator)/T/T);
         bnTarget = ct[0] / arith_uint256(K);
@@ -149,7 +149,7 @@ arith_uint256 oldRT_CST_RST(int32_t height,uint32_t nTime,arith_uint256 bnTarget
 arith_uint256 RT_CST_RST_outer(int32_t height,uint32_t nTime,arith_uint256 bnTarget,uint32_t *ts,arith_uint256 *ct,int32_t numerator,int32_t denominator,int32_t W,int32_t past)
 {
     int64_t outerK; arith_uint256 mintarget = bnTarget / arith_uint256(2);
-    if ( (ts[0] - ts[W]) < (T * numerator)/denominator )
+    if ( (int32_t) (ts[0] - ts[W]) < (int32_t) (T * numerator)/denominator )
     {
         outerK = (K * (nTime-ts[0]) * (ts[0]-ts[W]) * denominator) / (numerator * (T * T));
         if ( outerK < K )

--- a/src/pow.cpp
+++ b/src/pow.cpp
@@ -85,7 +85,7 @@ arith_uint256 oldRT_CST_RST(int32_t height,uint32_t nTime,arith_uint256 bnTarget
     if ( height < 64 )
         return(bnTarget);
     //if ( ((ts[0]-ts[W]) * W * 100)/(W-1) < (T * numerator * 100)/denominator )
-    if ( (ts[0] - ts[W]) < (T * numerator)/denominator )
+    if ( (uint32_t)(ts[0] - ts[W]) < (T * numerator)/denominator )
     {
         //bnTarget = ((ct[0]-ct[1])/K) * max(K,(K*(nTime-ts[0])*(ts[0]-ts[W])*denominator/numerator)/T/T);
         bnTarget = ct[0] / arith_uint256(K);


### PR DESCRIPTION
This code change fixes some compilation warnings. This change is **not** consensus change, update is not mandatory.

As discussed with jl777, compilation warnings can become errors on recent compilers and uninitialized variables can be dangerous. Some comparisons (copy pasted from komodo coming from zawy's code) compared unsigned integers with signed integers, I added a cast to have signed operands in the comparison.

Tested on Ubuntu 16.04,18.04 and 20.04.

Please contact me if you have other compilation warnings or errors in the aPoW code (mostly in pow.cpp).

A PR was opened to chips-blockchain repository:
https://github.com/chips-blockchain/chips/pull/4