### PR TITLE
fix compilation and linking for ubuntu 21.04

### DIFF
--- a/src/cryptoconditions/src/internal.h
+++ b/src/cryptoconditions/src/internal.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <Condition.h>
 #include <Fulfillment.h>
 #include "include/cJSON.h"

--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -2,6 +2,8 @@
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
 
+#include <deque>
+
 #include <httpserver.h>
 
 #include <chainparamsbase.h>

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -47,6 +47,10 @@
 #include <boost/algorithm/string/join.hpp>
 #include <boost/thread.hpp>
 
+#include <boost/bind/bind.hpp>
+
+using namespace boost::placeholders;
+
 #if defined(NDEBUG)
 # error "Bitcoin cannot be compiled without assertions."
 #endif

--- a/src/validationinterface.cpp
+++ b/src/validationinterface.cpp
@@ -18,6 +18,8 @@
 #include <future>
 
 #include <boost/signals2/signal.hpp>
+#include <boost/bind/bind.hpp>
+using namespace boost::placeholders;
 
 struct MainSignalsInstance {
     boost::signals2::signal<void (const CBlockIndex *, const CBlockIndex *, bool fInitialDownload)> UpdatedBlockTip;


### PR DESCRIPTION
To reprodece, please follow the instructions here: https://docs.komodoplatform.com/notary/setup-Komodo-Notary-Node.html#_3rd-party-server-setup

- Deque include is required to use std::deque: https://en.cppreference.com/w/cpp/container/deque:

```
httpserver.cpp:73:10: error: ‘deque’ in namespace ‘std’ does not name a template type
   73 |     std::deque<std::unique_ptr<WorkItem>> queue;
```

- internal.h seems to be included multiple time - producing multiple error definition, pragma once allowing us to prevent such a behaviour:

```
/usr/bin/ld: cryptoconditions/.libs/libcryptoconditions_core.a(utils.o):/home/milerius/chips3/src/cryptoconditions/src/internal.h:45: multiple definition of `CCTypeRegistryLength'; cryptoconditions/.libs/libcryptoconditions_core.a(cryptoconditions.o):/home/milerius/chips3/src/cryptoconditions/./src/internal.h:45: first defined here
/usr/bin/ld: cryptoconditions/.libs/libcryptoconditions_core.a(utils.o):/home/milerius/chips3/src/cryptoconditions/src/internal.h:44: multiple definition of `CCTypeRegistry'; cryptoconditions/.libs/libcryptoconditions_core.a(cryptoconditions.o):/home/milerius/chips3/src/cryptoconditions/./src/internal.h:44: first defined here
```

- boost place holders `_1, _2, _3` and so on required the namespace boost::placeholders; to be used:

```
/usr/include/boost/bind.hpp:36:1: note: ‘#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’

validationinterface.cpp:96:124: error: ‘_3’ was not declared in this scope
   96 |     g_signals.m_internals->BlockConnected.disconnect(boost::bind(&CValidationInterface::BlockConnected, pwalletIn, _1, _2, _3));
```


Both tested with gcc 8, and 10 + boost 1.74 (https://www.ubuntuupdates.org/package/core/hirsute/main/base/libboost-dev with 21.04)